### PR TITLE
feat: Refactor MCTS to use lazy instantiation for performance

### DIFF
--- a/experiment_modules/architecture_trainer.py
+++ b/experiment_modules/architecture_trainer.py
@@ -629,7 +629,7 @@ class ArchitectureTrainer:
                         experience['mcts_policy'] = np.array(visit_distribution, dtype=np.float32)
 
                     # Store the actual action objects
-                    experience['mcts_actions'] = [child.action for child in search_root.children]
+                    experience['mcts_actions'] = [child.action for child in search_root.children.values()]
                     
             except Exception as e:
                 print(f"    [Warning] Failed to extract MCTS policy: {e}")


### PR DESCRIPTION
Implements a lazy instantiation model in the MCTS algorithm to address performance bottlenecks.

The _expand method now only evaluates a leaf node with the neural network and stores action priors. The _select method traverses the tree and creates child nodes on-demand.

This change significantly reduces computation in the expansion step and lowers memory overhead.

Re-implements Dirichlet noise for the root node to ensure proper exploration. Fixes a bug where the root node was not expanded before the search began.